### PR TITLE
Fixing include paths for dav1d target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,6 +635,8 @@ set(LIBDAV1D_INCLUDE_DIRS_PRIV
 set(LIBDAV1D_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/dav1d/include
     ${CMAKE_CURRENT_BINARY_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/dav1d/include/dav1d
+    ${CMAKE_CURRENT_BINARY_DIR}/include/dav1d
 )
 
 # The final dav1d library


### PR DESCRIPTION
Adjusting include dirs, because `dav1d.h` header wants to include other headers not prefixed with `dav1d/`, which is possibly an issue in the source code, but we have to workaround it at this time.