### PR TITLE
Adding dav1d::dav1d alias for dav1d, which is a usual practice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -644,6 +644,8 @@ target_include_directories(dav1d PUBLIC ${LIBDAV1D_INCLUDE_DIRS})
 target_compile_options(dav1d PRIVATE ${STACKALIGN_FLAG} ${STACKREALIGN_FLAG})
 target_compile_definitions(dav1d PRIVATE ${TEMP_COMPILE_DEFS} ${API_EXPORT_DEFS})
 
+add_library(dav1d::dav1d ALIAS dav1d)
+
 if(STACKREALIGN_FLAG)
     set_source_files_properties(${LIBDAV1D_ENTRYPOINT_SOURCES} PROPERTIES COMPILE_FLAGS ${STACKREALIGN_FLAG})
 endif()


### PR DESCRIPTION
Adding alias so that the user can link against dav1d::dav1d