### PR TITLE
Linking against libdl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,6 +659,10 @@ else()
     set_target_properties(dav1d PROPERTIES PREFIX "lib")
 endif()
 
+if (NOT ("x${CMAKE_DL_LIBS}" STREQUAL "x"))
+    target_link_libraries(dav1d ${CMAKE_DL_LIBS})
+endif()
+
 if(NOT HAS_STDATOMIC)
     target_link_libraries(dav1d stdatomic_dependency)
 endif()


### PR DESCRIPTION
Linking against libdl, as a missing dlsym reference has been spotted in Debian:

```
/usr/bin/ld: libdav1d.so.4: undefined reference to `dlsym'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/dav1d_exe.dir/build.make:259: dav1d] Error 1
make[1]: *** [CMakeFiles/Makefile2:140: CMakeFiles/dav1d_exe.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```